### PR TITLE
Do not use the PR creator as reviewer

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,11 +81,6 @@ runs:
          echo "pr_user=$pr_user" >> $GITHUB_ENV
          echo "pull request user: " $pr_user
 
-         pr_comments=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/comments' \
-         --header 'Accept: application/vnd.github+json' \
-         --header 'Authorization: Bearer ${{ github.token }}' \
-         --header 'X-GitHub-Api-Version: 2022-11-28')
-         echo $pr_comments
          pr_commits_full=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits' \
          --header 'Accept: application/vnd.github+json' \
          --header 'Authorization: Bearer ${{ github.token }}' \
@@ -98,27 +93,18 @@ runs:
          } >> "$GITHUB_ENV"
          echo $PR_COMMITS_GHENV
 
-         pr_requested_reviewers=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers' \
-         --header 'Accept: application/vnd.github+json' \
-         --header 'Authorization: Bearer ${{ github.token }}' \
-         --header 'X-GitHub-Api-Version: 2022-11-28')
-         echo $pr_requested_reviewers
          pr_reviews=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews' \
          --header 'Accept: application/vnd.github+json' \
          --header 'Authorization: Bearer ${{ github.token }}' \
          --header 'X-GitHub-Api-Version: 2022-11-28')
-         pr_others=$(echo $pr_reviews | jq 'map(.user.login) | unique' |sed 's/\[//g' | sed 's/\]//g' | sed 's/\,//g' | sed 's/\"//g')
-         echo "pull reviewers: " $pr_others
+         pr_reviewers=$(echo $pr_reviews | jq 'map(.user.login) | unique' |sed 's/\[//g' | sed 's/\]//g' | sed 's/\,//g' | sed 's/\"//g')
+         echo "pull reviewers: " $pr_reviewers
          {
          echo 'PR_REVIEWERS_GHENV<<EOF'
-         echo $pr_others
+         echo $pr_reviewers
          echo EOF
          } >> "$GITHUB_ENV"
          echo $PR_REVIEWERS_GHENV
-         pr_reviews=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews' \
-         --header 'Accept: application/vnd.github+json' \
-         --header 'Authorization: Bearer ${{ github.token }}' \
-         --header 'X-GitHub-Api-Version: 2022-11-28')
          pr_approver=$(echo $pr_reviews | jq  -rce 'map(select(.state == "APPROVED"))' | jq 'map(.user.login) | unique' |sed 's/\[//g' | sed 's/\]//g' | sed 's/\,//g' | sed 's/\"//g')
          echo "pull request approver: " $pr_approver
          {
@@ -135,7 +121,11 @@ runs:
         for pr_patch in `echo $PR_PATCHES_GHENV`; do \
           echo "trail pr for patch number: " $pr_patch 
           for i in `echo $PR_REVIEWERS_GHENV`; do \
-            echo "reviewers item:  $i"
+            if [[ "$i" == "$pr_user" ]]; then
+              continue
+            fi
+            echo "Author was $pr_user"
+            echo "reviewers item: $i"
             gh_user=$(echo ${{ env.USERINFO }} | base64 -d | yq .users.$i - )
             echo "user: $gh_user"
             if ! [[ $gh_user == "null" ]]; then


### PR DESCRIPTION
Our workflow gets the info regarding the reviewers by using the `/reviews` endpoint of Github API. However, this endpoint will return all the comments from the review. As a result, all users who have participated in the review (e.g. commenting in the code) will be also part of the review. Therefore, when we get the users of a review, we might end up getting the author of the PR as a reviewer too (when the PR author responds in a review comment for a code line).

For that purpose, we need to check if the author is the same as the reviewer right before applying the reviewer-by git trailers.

Also remove unused code.