### PR TITLE
Change value of items per page, when requesting reviews from the Github API

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
          } >> "$GITHUB_ENV"
          echo $PR_COMMITS_GHENV
 
-         pr_reviews=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews' \
+         pr_reviews=$(curl --location 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=300' \
          --header 'Accept: application/vnd.github+json' \
          --header 'Authorization: Bearer ${{ github.token }}' \
          --header 'X-GitHub-Api-Version: 2022-11-28')


### PR DESCRIPTION
Github API uses pagination https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28 and therefore when we have a lot of comments in a review, we might not be able to get the final APPROVED review in one request.  For that purpose, we change the number of items per page when we request the reviews from the Github API to 300.

Hopefully, this value will be enough.